### PR TITLE
Print errors to standard error and dont use basename

### DIFF
--- a/dropbox
+++ b/dropbox
@@ -19,7 +19,7 @@ CONF_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/zi_dropbox"
 # Error stuff (and instruction on how to use this script)
 err()
 {
-	echo "Usage: dropbox [OPTION...] [FILE]
+	>&2 echo "Usage: dropbox [OPTION...] [FILE]
 
 Options:
   -h		show this message
@@ -42,8 +42,8 @@ shift $((OPTIND - 1))
 # Get file from argument
 [ -z "$@" ] && err
 LOCAL="$@"
-[ ! -e "$LOCAL" ] && echo "File called $LOCAL not Found!" && exit 1
-FILENAME="$(basename "$LOCAL")"
+[ ! -e "$LOCAL" ] && >&2 echo "File called $LOCAL not Found!" && exit 1
+FILENAME="${LOCAL##*/}"
 
 # Log
 # LOG_DIR="${XDG_DATA_HOME:-$HOME/local/share}/zi_dropbox" 
@@ -57,7 +57,7 @@ RESULT=$(curl -X POST https://content.dropboxapi.com/2/files/upload \
 	--header "Dropbox-API-Arg: {\"path\": \"/$DIRECTORY/${DB_FILENAME:-$(date "+%Y-%m-%d")-$FILENAME}\",\"mode\": \"add\",\"autorename\": true,\"mute\": false,\"strict_conflict\": false}" \
 	--header "Content-Type: application/octet-stream" \
 	--data-binary @"$LOCAL")
-[ "$(echo $RESULT | jq .error)" = "null" ] && echo "Succesfully uploaded $FILENAME" || $(echo "An error occurred!" && exit 1)
+[ "$(echo $RESULT | jq .error)" = "null" ] && echo "Succesfully uploaded $FILENAME" || { >&2 echo "An error occurred!"; exit 1; }
 
 # Share file then print the url
 [ ${SHARE:-0} -lt 1 ] && exit 0


### PR DESCRIPTION
`>&2` redirects output headed to standard output to standard error, where errors are meant to go

`${VAR##*/}` strips all the directories from a filepath, and is much faster than calling `basename`